### PR TITLE
[HOTFIX] [overrides the devise session controller]

### DIFF
--- a/app/controllers/overrides/sessions_controller.rb
+++ b/app/controllers/overrides/sessions_controller.rb
@@ -1,0 +1,10 @@
+class Overrides::SessionsController < DeviseTokenAuth::SessionsController
+
+  protected
+
+  def render_create_success
+    render json: {
+      data: resource_data(resource_json: @resource.token_validation_response)
+    }, scope: :current_admin
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount_devise_token_auth_for 'User', at: 'user_auth'
-  mount_devise_token_auth_for 'Admin', at: 'admin_auth'
+  mount_devise_token_auth_for 'User', at: 'auth'
+  mount_devise_token_auth_for 'Admin', at: 'admin_auth',  controllers: {
+    sessions: 'overrides/sessions',
+  }
   # as :admin do
   #   # Define routes for Admin within this block.
   # end


### PR DESCRIPTION
## Resolves
* the scope of devise token auth for multiple models
* creates a new scope called `current_admin` and return it as the current logged user when an admin is requesting a sign in.